### PR TITLE
Fix lexeme position for varE' function

### DIFF
--- a/VerySimpleExpressions.lhs
+++ b/VerySimpleExpressions.lhs
@@ -380,8 +380,8 @@ but gives effectively the same function.
 
 > varE' :: Parser SimpleExpr
 > varE' = do
->     fc <- lexeme $ firstChar
->     rest <- many nonFirstChar
+>     fc <- firstChar
+>     rest <- lexeme $ many nonFirstChar
 >     return $ Var (fc:rest)
 >   where
 >     firstChar = satisfy (\a -> isLetter a || a == '_')


### PR DESCRIPTION
Current version parses such string: "v arName", but not "varName ".
